### PR TITLE
[feat] Allow origin to have '[hash]'

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ module.exports = {
     plugins: [
         new CreateSymlinkPlugin([
             {
-                origin: 'index.html',
+                origin: 'index-[hash].html',
                 symlink: '200.html',
             },
         ])
@@ -28,7 +28,7 @@ module.exports = {
     plugins: [
         new CreateSymlinkPlugin([
             {
-                origin: 'index.html',
+                origin: 'index-[hash].html',
                 symlink: '200.html',
             },
             true

--- a/dist/index.js
+++ b/dist/index.js
@@ -33,7 +33,9 @@ module.exports = function () {
 
                 var makeSymlinks = function makeSymlinks(option) {
                     var outputPath = compiler.options.output.path;
-                    var originPath = path.join(outputPath, option.origin);
+                    // allow origin to have webpack '[hash]' placeholder
+                    var originFileName = option.origin.replace('[hash]', compilation.hash);
+                    var originPath = path.join(outputPath, originFileName);
                     var reportProgress = context && context.reportProgress;
 
                     if (fs.existsSync(originPath) || _this.force) {

--- a/package.json
+++ b/package.json
@@ -19,5 +19,11 @@
     "build": "babel src/index.js --presets es2015 --out-file dist/index.js"
   },
   "author": "nystudio107",
+  "contributors": [
+    {
+      "name": "Luiza Pagliari",
+      "email": "lpagliari@gmail.com"
+    }
+  ],
   "license": "MIT"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,9 @@ module.exports = class CreateSymlinkPlugin {
 
                 const makeSymlinks = (option) => {
                     const outputPath = compiler.options.output.path;
-                    const originPath = path.join(outputPath, option.origin);
+                    // allow origin to have webpack '[hash]' placeholder
+                    const originFileName = option.origin.replace('[hash]', compilation.hash);
+                    const originPath = path.join(outputPath, originFileName);
                     const reportProgress = context && context.reportProgress;
 
                     if (fs.existsSync(originPath) || this.force) {


### PR DESCRIPTION
Webpack allows some [templates](https://webpack.js.org/configuration/output/#outputdevtoolmodulefilenametemplate) to be used on its filenames. One of them is `'[hash]'`, which contains the hash of the module identifier.

If the webpack configs include `[hash]` on the origin filename, replace it with the actual hash.

This PR avoids this kind of issue:
![image](https://user-images.githubusercontent.com/836386/53041062-c7332280-3461-11e9-8c76-c979f16117af.png)

Should be:
![image](https://user-images.githubusercontent.com/836386/53041158-03ff1980-3462-11e9-8cbd-56730c83398e.png)
